### PR TITLE
debug support print more than one table

### DIFF
--- a/lib/lor/lib/debug.lua
+++ b/lib/lor/lib/debug.lua
@@ -1,8 +1,47 @@
 local pcall = pcall
 local type = type
 local pairs = pairs
+local tostring = tostring
+local sformat = string.format
+local tunpack = table.unpack
+local tconcat = table.concat
+local tinsert = table.insert
+local getmetatable = getmetatable
 
 
+function serialize(t)
+    local mark = {}
+    local assign = {}
+ 
+    local function ser_table(tbl,parent)
+        mark[tbl] = parent
+        local tmp = {}
+        for k,v in pairs(tbl) do
+            local key = type(k)=="number" and "["..k.."]" or k
+            if type(v)=="table" then
+                if getmetatable(v) and type(v.__tostring)=="function" then
+                    tinsert(tmp, key.."="..tostring(v))
+                else
+                    local dotkey = parent..(type(k)=="number" and key or "."..key)
+                    if mark[v] then
+                        tinsert(assign,dotkey.."="..mark[v])
+                    else
+                        tinsert(tmp, key.."="..ser_table(v,dotkey))
+                    end
+                end
+            else
+                if type(v)=="string" then
+                    v = sformat("%q", v)
+                end
+                tinsert(tmp, key.."="..tostring(v))
+            end
+        end
+        return "{"..tconcat(tmp,",").."}"
+    end
+ 
+    return ser_table(t,"")
+end
+ 
 local function debug(...)
     if not LOR_FRAMEWORK_DEBUG then
         return
@@ -12,12 +51,8 @@ local function debug(...)
     if next(info) then
         if type(info[1]) == 'function' then
             pcall(function() info[1]() end)
-        elseif type(info[1]) == 'table' then
-            for i, v in pairs(info[1]) do
-                print(i, v)
-            end
         else
-            print(...)
+            print(serialize(info))
         end
     else
         print("debug not works...")


### PR DESCRIPTION
https://github.com/sumory/lor/blob/master/lib/lor/lib/application.lua#L99  当使用middleware时报下面的错

```
: *1 lua entry thread aborted: runtime error: .../server/openresty/site/lualib/lor/lib/debug.lua:20: bad argument #2 to 'print' (string, number, boolean, or nil expected, got function)
stack traceback:
coroutine 0:
        [C]: in function 'print'
        .../server/openresty/site/lualib/lor/lib/debug.lua:20: in function 'debug'
        .../server/openresty/site/lualib/lor/lib/application.lua:99: in function 'use'
        ./app/main.lua:11: in function
```