### PR TITLE
feat: update router validation to support `~`

### DIFF
--- a/lib/lor/lib/trie.lua
+++ b/lib/lor/lib/trie.lua
@@ -16,11 +16,11 @@ local Node = require("lor.lib.node")
 local NodeHolder = holder.NodeHolder
 local Matched = holder.Matched
 local mixin = utils.mixin
-local valid_segment_tip = "valid path should only contains: [A-Za-z0-9._-]"
+local valid_segment_tip = "valid path should only contains: [A-Za-z0-9._-~]"
 
 
 local function check_segment(segment)
-    local tmp = string_gsub(segment, "([A-Za-z0-9._-]+)", "")
+    local tmp = string_gsub(segment, "([A-Za-z0-9._-~]+)", "")
     if tmp ~= "" then
         return false
     end


### PR DESCRIPTION
Sometime we want `~` to indicates internal urls.

> http://foo/~manage