### PR TITLE
fixed req.session.set to support multiple called in one request

### DIFF
--- a/lib/lor/lib/middleware/session.lua
+++ b/lib/lor/lib/middleware/session.lua
@@ -53,14 +53,17 @@ local session_middleware = function(config)
         -- local session = Session.new(config)
         req.session = {
             set = function(key, value)
-                local s = Session:open({
-                    secret = config.secret
-                })
+                local s = req.session_opened
+                if not s then
+                    s = Session:open({
+                        secret = config.secret
+                    })
+                    s.cookie.persistent = true
+                    s.cookie.lifetime = config.timeout
+                    req.session_opened = s
+                end
 
                 s.data[key] = value
-
-                s.cookie.persistent = true
-                s.cookie.lifetime = config.timeout
                 s.expires = ngx_time() + config.timeout
                 s:save()
             end,


### PR DESCRIPTION
解决像这样的问题:
连续多次 
req.session.set(key_1, val_1)
req.session.set(key_2, val_2)
req.session.set(key_3, val_3)

只有最后一个set的key_3生效，而key_1,key_2 set不了.
