### PR TITLE
fallback_lookup去掉pipeline生成

### DIFF
--- a/lib/lor/lib/trie.lua
+++ b/lib/lor/lib/trie.lua
@@ -260,7 +260,6 @@ function Trie:fallback_lookup(fallback_stack, segments, params)
 
     if flag and parent.endpoint then
         matched.node = parent
-        matched.pipeline = get_pipeline(parent)
     end
 
     if matched.node then


### PR DESCRIPTION
fallback_lookup生成的pipeline会在_match中重复生成