### PR TITLE
fix missing header [content-length]

### DIFF
--- a/lib/lor/lib/response.lua
+++ b/lib/lor/lib/response.lua
@@ -107,6 +107,7 @@ end
 --~=============================================================
 
 function Response:_send(content)
+    ngx.header['Content-Length'] = #content
     ngx.status =  self.http_status or 200
     ngx.say(content)
 end


### PR DESCRIPTION
missing content-length will cause a '\n' append to the response